### PR TITLE
Update datetime.tcc

### DIFF
--- a/include/asap/datetime.tcc
+++ b/include/asap/datetime.tcc
@@ -51,9 +51,7 @@ namespace asap {
       std::stringstream ss(datetime);
       ss.imbue(std::locale(""));
       ss >> std::get_time(&when, fmt.c_str());
-      if (ss.fail()) {
-		    continue;
-	    }
+      if (ss.fail()) continue;
       if (str(fmt) == datetime) break;
     }
   }

--- a/include/asap/datetime.tcc
+++ b/include/asap/datetime.tcc
@@ -51,6 +51,9 @@ namespace asap {
       std::stringstream ss(datetime);
       ss.imbue(std::locale(""));
       ss >> std::get_time(&when, fmt.c_str());
+      if (ss.fail()) {
+		    continue;
+	    }
       if (str(fmt) == datetime) break;
     }
   }


### PR DESCRIPTION
[stdget-time-how-to-check-for-parsing-error](https://stackoverflow.com/questions/30283381/stdget-time-how-to-check-for-parsing-error)

In Visual Studio 2017 on Windows 10, asap demo code:asap/examples/datetime/datetime.cc would be crash for std::get_time parsing error. crash snippet:
```c++
asap::datetime d2("08/07/1987");
std::cout << "d2          ->   " << d2.str("%c") << std::endl;
```